### PR TITLE
[WIP] Update pr-builder.yml bump actions/cache version and add jdk 11 and 17 builds

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -17,16 +17,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        java-version: [ 11, 17 ]
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Adopt JDK 8
+      - name: Set up Adopt JDK 11 and 17
         uses: actions/setup-java@v2
         with:
-          java-version: "8"
+          java-version: ${{ matrix.java-version }}
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-m2
         with:


### PR DESCRIPTION
## Purpose
> Bump actions/cache version since v2 is deprecated.

## Related Issue 
- https://github.com/wso2/product-is/issues/23500