### PR TITLE
Bump nimbus-jose-jwt version to 10.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,8 +209,8 @@
         <servlet-api.version>2.5</servlet-api.version>
         <imp.pkg.version.javax.servlet>[2.5.0, 3.0.0)</imp.pkg.version.javax.servlet>
 
-        <nimbusds.version>7.3.0.wso2v1</nimbusds.version>
-        <nimbusds.osgi.version.range>[7.3.0,8.0.0)</nimbusds.osgi.version.range>
+        <nimbusds.version>10.3.0.wso2v1</nimbusds.version>
+        <nimbusds.osgi.version.range>[10.3.0.wso2v1, 11.0.0)</nimbusds.osgi.version.range>
         <json-smart.version>2.4.8</json-smart.version>
         <json-smart.version.range>[2.3.0, 3.0.0)</json-smart.version.range>
 


### PR DESCRIPTION
### Purpose
> The nimbus library needs to be bumped in the product due. 

### Related Issue/s 
- https://github.com/wso2/product-is/issues/23582